### PR TITLE
allow width and height of framebuffers and textures to be set indepen…

### DIFF
--- a/src/Framebuffer.js
+++ b/src/Framebuffer.js
@@ -9,19 +9,24 @@ glx.Framebuffer.prototype = {
     this.frameBuffer = GL.createFramebuffer();
     GL.bindFramebuffer(GL.FRAMEBUFFER, this.frameBuffer);
 
+    width = glx.util.nextPowerOf2(width);
+    height= glx.util.nextPowerOf2(height);
+    
+    if (width === this.width && height === this.height) //already has the right size
+      return;
+    
     this.width  = width;
     this.height = height;
-    var size = glx.util.nextPowerOf2(Math.max(this.width, this.height));
 
     this.renderBuffer = GL.createRenderbuffer();
     GL.bindRenderbuffer(GL.RENDERBUFFER, this.renderBuffer);
-    GL.renderbufferStorage(GL.RENDERBUFFER, GL.DEPTH_COMPONENT16, size, size);
+    GL.renderbufferStorage(GL.RENDERBUFFER, GL.DEPTH_COMPONENT16, width, height);
 
     if (this.renderTexture) {
       this.renderTexture.destroy();
     }
 
-    this.renderTexture = new glx.texture.Data(size);
+    this.renderTexture = new glx.texture.Data(width, height);
 
     GL.framebufferRenderbuffer(GL.FRAMEBUFFER, GL.DEPTH_ATTACHMENT, GL.RENDERBUFFER, this.renderBuffer);
     GL.framebufferTexture2D(GL.FRAMEBUFFER, GL.COLOR_ATTACHMENT0, GL.TEXTURE_2D, this.renderTexture.id, 0);

--- a/src/texture/Data.js
+++ b/src/texture/Data.js
@@ -1,5 +1,5 @@
 
-glx.texture.Data = function(size, data, options) {
+glx.texture.Data = function(width, height, data, options) {
   //options = options || {};
 
   this.id = GL.createTexture();
@@ -15,12 +15,12 @@ glx.texture.Data = function(size, data, options) {
   var bytes = null;
 
   if (data) {
-    var length = size*size*4;
+    var length = width*height*4;
     bytes = new Uint8Array(length);
     bytes.set(data.subarray(0, length));
   }
 
-  GL.texImage2D(GL.TEXTURE_2D, 0, GL.RGBA, size, size, 0, GL.RGBA, GL.UNSIGNED_BYTE, bytes);
+  GL.texImage2D(GL.TEXTURE_2D, 0, GL.RGBA, width, height, 0, GL.RGBA, GL.UNSIGNED_BYTE, bytes);
   GL.bindTexture(GL.TEXTURE_2D, null);
 };
 


### PR DESCRIPTION
…dently (fixes #2 )

Allowing non-square textures was not initially planned, but was necessary for non-square framebuffers as they internally create a framebuffer texture.
